### PR TITLE
Fix symlink permissions setting in FS exporter

### DIFF
--- a/exporter/fs.go
+++ b/exporter/fs.go
@@ -70,16 +70,26 @@ func (p *FSExporter) StoreFile(ctx context.Context, pathname string, fp io.Reade
 }
 
 func (p *FSExporter) SetPermissions(ctx context.Context, pathname string, fileinfo *objects.FileInfo) error {
-	if err := os.Chmod(pathname, fileinfo.Mode()); err != nil {
-		return err
-	}
-	if os.Getuid() == 0 {
-		if err := os.Chown(pathname, int(fileinfo.Uid()), int(fileinfo.Gid())); err != nil {
+	if fileinfo.Mode()&os.ModeSymlink == 0 {
+		if err := os.Chmod(pathname, fileinfo.Mode()); err != nil {
 			return err
 		}
 	}
-	if err := os.Chtimes(pathname, fileinfo.ModTime(), fileinfo.ModTime()); err != nil {
-		return err
+	if os.Getuid() == 0 {
+		if fileinfo.Mode()&os.ModeSymlink != 0 {
+			if err := os.Lchown(pathname, int(fileinfo.Uid()), int(fileinfo.Gid())); err != nil {
+				return err
+			}
+		} else {
+			if err := os.Chown(pathname, int(fileinfo.Uid()), int(fileinfo.Gid())); err != nil {
+				return err
+			}
+		}
+	}
+	if fileinfo.Mode()&os.ModeSymlink == 0 {
+		if err := os.Chtimes(pathname, fileinfo.ModTime(), fileinfo.ModTime()); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
- Skip os.Chmod for symlinks as it follows the link and affects the target
- Use os.Lchown for symlinks to operate on the link itself
- Skip os.Chtimes for symlinks to avoid following the link

This ensures proper permission handling for symbolic links.