### PR TITLE
ignore files names we cannot parse

### DIFF
--- a/storage/buckets.go
+++ b/storage/buckets.go
@@ -73,7 +73,7 @@ func (buckets *Buckets) List() ([]objects.MAC, error) {
 			if entry.Name() == "." || entry.Name() == ".." {
 				continue
 			}
-			if entry.IsDir() {
+			if !entry.Type().IsRegular() {
 				continue
 			}
 			t, err := hex.DecodeString(entry.Name())

--- a/storage/buckets.go
+++ b/storage/buckets.go
@@ -78,7 +78,8 @@ func (buckets *Buckets) List() ([]objects.MAC, error) {
 			}
 			t, err := hex.DecodeString(entry.Name())
 			if err != nil {
-				return nil, err
+				// XXX ignore the gibberish?
+				continue
 			}
 			if len(t) != 32 {
 				continue


### PR DESCRIPTION
Spotted in https://github.com/PlakarKorp/plakar/issues/1762#issuecomment-3512634607, where another tool that creates files in the kloset makes it inaccessible for any use.

I'm still not completely sure, but this at least makes the kloset workable on such situations.