### PR TITLE
exporter: set the btime on windows

### DIFF
--- a/exporter/fs.go
+++ b/exporter/fs.go
@@ -86,14 +86,8 @@ func (p *FSExporter) SetPermissions(ctx context.Context, pathname string, filein
 			}
 		}
 	}
-	if fileinfo.Mode()&os.ModeSymlink != 0 {
-		if err := Lutimes(pathname, fileinfo.ModTime(), fileinfo.ModTime()); err != nil {
-			return err
-		}
-	} else {
-		if err := os.Chtimes(pathname, fileinfo.ModTime(), fileinfo.ModTime()); err != nil {
-			return err
-		}
+	if err := Lutimes(pathname, fileinfo.ModTime(), fileinfo.ModTime()); err != nil {
+		return err
 	}
 	return nil
 }

--- a/exporter/lutimes_windows.go
+++ b/exporter/lutimes_windows.go
@@ -4,9 +4,21 @@ package exporter
 
 import (
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 func Lutimes(path string, atime time.Time, mtime time.Time) error {
-	// Windows doesn't support Lutimes for symlinks
-	return nil
+	handle, err := windows.Open(path, windows.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer windows.Close(handle)
+
+	var (
+		access   = windows.NsecToFiletime(atime.UnixNano())
+		creation = windows.NsecToFiletime(mtime.UnixNano())
+	)
+
+	return windows.SetFileTime(handle, &creation, &access, &creation)
 }


### PR DESCRIPTION
* to simplify the logic, always attempt to call Lutimes() regardless of the file status.  On unix, it doesn't matter.

* on windows, make Lutimes() use SetFileTime() which allows to set the ``birth date'' of a file (i.e. the creation time). os.Chtimes() sets the ctime as mtime on windows, leaving btime set to now.