### PR TITLE
walkdir: Do not stop walkDir works on context cancellation.

### DIFF
--- a/importer/walkdir.go
+++ b/importer/walkdir.go
@@ -45,8 +45,6 @@ func (f *FSImporter) walkDir_worker(ctx context.Context, jobs <-chan file, recor
 			if !ok {
 				return
 			}
-		case <-ctx.Done():
-			return
 		}
 
 		// fixup the rootdir if it happened to be a file


### PR DESCRIPTION
* We need them to drain the jobs channel otherwise it's a deadlock.