### PR TITLE
rework err str

### DIFF
--- a/importer/walkdir.go
+++ b/importer/walkdir.go
@@ -19,10 +19,12 @@ package importer
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/PlakarKorp/kloset/connectors"
@@ -54,7 +56,12 @@ func (f *FSImporter) walkDir_worker(ctx context.Context, jobs <-chan file, recor
 
 		extendedAttributes, err := xattr.LList(p.path)
 		if err != nil {
-			records <- connectors.NewError(p.path, err)
+			errString := err.Error()
+			_, after, found := strings.Cut(errString, "xattr.list "+p.path+": ")
+			if found {
+				errString = after
+			}
+			records <- connectors.NewError(p.path, fmt.Errorf("%s", errString))
 			continue
 		}
 


### PR DESCRIPTION
xattr package formats errors in a very annoying way by prefixing xattr.list path in front, leading to such messages all over the place:

✘ /private/etc/krb5.keytab: xattr.list /private/etc/krb5.keytab: permission denied
✘ /private/etc/master.passwd: xattr.list /private/etc/master.passwd: permission denied

we can strip its prefix and produce:

✘ /private/etc/krb5.keytab: permission denied
✘ /private/etc/master.passwd: permission denied