### PR TITLE
make sure that we bailout if something is fishy with restore paths

### DIFF
--- a/exporter/fs.go
+++ b/exporter/fs.go
@@ -50,10 +50,21 @@ func NewFSExporter(ctx context.Context, opts *connectors.Options, name string, c
 	location := config["location"]
 	rootDir := strings.TrimPrefix(location, name+"://")
 
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		return nil, err
+	}
+
 	return &FSExporter{
 		opts:    opts,
-		rootDir: rootDir,
+		rootDir: absRoot,
 	}, nil
+}
+
+// isContained reports whether path is rooted within root (or is root itself).
+// Both arguments must be clean absolute paths.
+func isContained(root, path string) bool {
+	return path == root || strings.HasPrefix(path, root+string(filepath.Separator))
 }
 
 func (p *FSExporter) Root() string          { return p.rootDir }
@@ -104,6 +115,10 @@ loop:
 			}
 
 			pathname := filepath.Join(p.rootDir, record.Pathname)
+			if !isContained(p.rootDir, pathname) {
+				results <- record.Error(fmt.Errorf("path %q escapes restore root", record.Pathname))
+				continue
+			}
 
 			if record.FileInfo.Lmode.IsDir() {
 				if err := os.Mkdir(pathname, 0700); err != nil {
@@ -159,6 +174,21 @@ loop:
 }
 
 func (p *FSExporter) symlink(record *connectors.Record, pathname string) error {
+	// Validate that the symlink target, when resolved relative to its location,
+	// stays within the restore root.  This prevents a malicious archive from
+	// planting a symlink whose target escapes the root and then writing through
+	// it with a subsequent entry.
+	target := record.Target
+	var resolved string
+	if filepath.IsAbs(target) {
+		resolved = filepath.Clean(target)
+	} else {
+		resolved = filepath.Join(filepath.Dir(pathname), target)
+	}
+	if !isContained(p.rootDir, resolved) {
+		return fmt.Errorf("symlink target %q escapes restore root", target)
+	}
+
 	if err := os.Symlink(record.Target, pathname); err != nil {
 		return err
 	}

--- a/exporter/fs.go
+++ b/exporter/fs.go
@@ -52,7 +52,7 @@ func NewFSExporter(ctx context.Context, opts *connectors.Options, name string, c
 
 	absRoot, err := filepath.Abs(rootDir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to absolutify root: %w", err)
 	}
 
 	return &FSExporter{
@@ -174,21 +174,6 @@ loop:
 }
 
 func (p *FSExporter) symlink(record *connectors.Record, pathname string) error {
-	// Validate that the symlink target, when resolved relative to its location,
-	// stays within the restore root.  This prevents a malicious archive from
-	// planting a symlink whose target escapes the root and then writing through
-	// it with a subsequent entry.
-	target := record.Target
-	var resolved string
-	if filepath.IsAbs(target) {
-		resolved = filepath.Clean(target)
-	} else {
-		resolved = filepath.Join(filepath.Dir(pathname), target)
-	}
-	if !isContained(p.rootDir, resolved) {
-		return fmt.Errorf("symlink target %q escapes restore root", target)
-	}
-
 	if err := os.Symlink(record.Target, pathname); err != nil {
 		return err
 	}


### PR DESCRIPTION
kloset is only supposed to emit absolute pathnames.

bail out if a received pathname evades the target directory, it means the record pathname was using directory parent escapes.

issue spotted by @poeck, fixed in kloset but its worth adding safety nets.